### PR TITLE
[#46] feat: 상대 프로필 정보 페이지 추가

### DIFF
--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -35,6 +35,7 @@ const JobDetailPage = () => {
   const [showMenu, setShowMenu] = useState(false);
 
   const [mine, setMine] = useState(false);
+  const [userId, setUserId] = useState<string>();
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -60,9 +61,9 @@ const JobDetailPage = () => {
       try {
         if (jobId) {
           const data = await fetchJobDetail(jobId);
-          console.log(data.result);
           setMine(data.result.mine || false);
           setBoardData(data.result);
+          setUserId(data.result.userId);
         }
       } catch (e) {
         setError('데이터를 불러오는 중 문제가 발생했습니다.');
@@ -150,7 +151,10 @@ const JobDetailPage = () => {
         )}
         <div className="flex w-full flex-col gap-5 px-6">
           <div className="flex items-center gap-3 text-xl font-semibold">
-            <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-full">
+            <div
+              className="relative h-12 w-12 shrink-0 overflow-hidden rounded-full"
+              onClick={() => router.push(`/profile/${userId}`)}
+            >
               <Image
                 src={boardData.profileUrl}
                 alt="profile"

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+import Image from 'next/image';
+import TrustLevel from '@/components/profile/TrustLevel';
+import { badgeData, initialProfile } from '@/lib/utils';
+import Badge from '@/components/common/badge';
+import { fetchProfile, fetchProfileById } from '@/lib/api/profile';
+import React, { useEffect, useState } from 'react';
+import { fetchProfileResponse } from '@/types/profile';
+import ImageSlider from '@/components/profile/ImageSlider';
+import Header from '@/components/common/header';
+import { useParams } from 'next/navigation';
+
+const ProfilePage = () => {
+  const [profile, setProfile] = useState<fetchProfileResponse>(initialProfile);
+  const params = useParams();
+  const userId = Number(params.id);
+  const [userName, setUserName] = useState<string>('');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await fetchProfileById(userId);
+        setProfile(data);
+        setUserName(profile.nickname);
+      } catch (e) {
+      } finally {
+      }
+    })();
+  }, []);
+
+  return (
+    <>
+      <Header
+        title={`${profile.nickname} 님의 정보`}
+        centerTitle={false}
+        showBackButton={true}
+      />
+      <div className="flex flex-col items-center gap-9 px-6 py-3 text-black">
+        <div className="flex w-full items-center gap-3">
+          <div className="border-main relative h-20 w-20 overflow-hidden rounded-full border">
+            <Image
+              src={
+                profile.profile_img ??
+                'https://harmoneybucket.s3.ap-northeast-2.amazonaws.com/upload/profile/2025/08/22/c47d3582-ef29-4b95-b06e-0fadc5a515d0.jpeg'
+              }
+              alt="profile"
+              fill
+              className="object-cover object-center"
+              unoptimized
+              sizes="48px"
+            />
+          </div>
+          <div className="flex flex-col gap-3 font-semibold">
+            <span className="text-2xl">{profile.nickname} 님</span>
+            <div className="flex items-center gap-2">
+              <div className="text-hana-green rounded-2xl bg-[#EAF9F6] px-2 py-1">
+                매칭 횟수
+              </div>
+              {profile.match_count}회
+            </div>
+          </div>
+        </div>
+        <div className="bg-hana-green-light flex w-full flex-col gap-4 rounded-xl p-5">
+          <span className="text-2xl font-semibold">기본 정보</span>
+          <div className="flex flex-col gap-12">
+            <span className="text-2xl">신뢰도</span>
+            <TrustLevel level={profile.trust} />
+          </div>
+          <div className="flex flex-col gap-3">
+            <span className="text-2xl">관심 카테고리</span>
+            <div className="flex flex-wrap gap-2">
+              {badgeData
+                .filter((item) => profile.category_ids.includes(item.id))
+                .map((item) => (
+                  <Badge key={item.id} active={true} text={item.text} />
+                ))}
+            </div>
+          </div>
+        </div>
+        <div className="flex w-full flex-col gap-6">
+          <span className="text-[26px] font-semibold">
+            {profile.nickname} 님 소개
+          </span>
+          <div className="flex flex-col gap-4 text-xl">
+            <span className="text-2xl">소개글</span>
+            <span className="font-light">{profile.description}</span>
+          </div>
+          <div className="flex flex-col gap-4 text-xl">
+            <span className="text-2xl">사진</span>
+            <div className="flex flex-wrap gap-3">
+              {profile.img_url_detail && profile.img_url_detail.length > 0 ? (
+                <ImageSlider images={profile.img_url_detail} />
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ProfilePage;

--- a/src/lib/api/profile.ts
+++ b/src/lib/api/profile.ts
@@ -68,6 +68,11 @@ export const fetchProfile = async () => {
   return res.result;
 };
 
+export const fetchProfileById = async (id: number) => {
+  const res = await apiClient(`/profile/${id}`);
+  return res.result;
+};
+
 export async function updateProfile(payload: EditProfilePayload) {
   const {
     nickname,

--- a/src/types/jobs.ts
+++ b/src/types/jobs.ts
@@ -16,6 +16,8 @@ export type JobDetailProps = Partial<JobsProps> & {
   nickname: string;
   profileUrl: string;
   trust: number;
+  mine?: boolean;
+  userId?: string;
 };
 
 export type JobBoard = JobsProps & {
@@ -26,8 +28,10 @@ export type JobBoard = JobsProps & {
   createdAt: string;
   updatedAt: string;
   phone?: string;
-  mine?: boolean;
-} & Pick<JobDetailProps, 'nickname' | 'trust' | 'profileUrl'>;
+} & Pick<
+    JobDetailProps,
+    'nickname' | 'trust' | 'profileUrl' | 'mine' | 'userId'
+  >;
 
 export type RegisterData = {
   title: string;


### PR DESCRIPTION
<!--- PR 제목을 "[카테고리] 구현한 거 설명" 으로 작성했나요? -->
<!--- ex)[feat] 로그인 API 연동 -->

## #️⃣ Issue Number
- #46 

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
- 일자리 상세에서 상대 프로필 클릭 시 상대 프로필 정보 페이지로 이동
- 상대방 프로필 페이지 추가

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 📸스크린샷 (선택)
화면명 | 설명 | 이미지
---|---|---
상대방 프로필 페이지 | 주소 및 버튼들 삭제 | <img width="335" height="718" alt="image" src="https://github.com/user-attachments/assets/222228da-fd9b-497d-a091-c85a1e8701d6" />

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
